### PR TITLE
34 feat 멋사 프론트엔드 7주차 과제

### DIFF
--- a/frontend/FEweek07/week07/src/pages/DetailPage.jsx
+++ b/frontend/FEweek07/week07/src/pages/DetailPage.jsx
@@ -8,6 +8,11 @@ const DetailPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
   const baseURL = import.meta.env.VITE_API_BASE_URL;
+  const [comment, setComment] = useState("");
+
+  const onChangeComment = (e) => {
+    setComment(e.target.value);
+  };
 
   const [detail, setDetail] = useState([]);
   const getDetail = (id) => {
@@ -34,19 +39,39 @@ const DetailPage = () => {
         alert("게시글을 삭제하지 못했습니다.");
       });
   };
+  const changeComment = () => {
+    axios
+      .put(`${baseURL}/entries/${id}/`, {
+        author: detail.author,
+        comment: comment,
+      })
+      .then((response) => {
+        console.log(response);
+        alert("게시글 수정이 완료되었습니다.");
+        navigate("/");
+      });
+  };
 
   useEffect(() => {
     getDetail(id);
   }, [id]);
+
+  useEffect(() => {
+    if (detail) {
+      setComment(detail.comment || "");
+    }
+  }, [detail]);
   return (
     <Wrapper>
       <Button txt="게시글 작성하기" onBtnClick={() => navigate("/write")} />
       <DetailWrapper>
         <Author>{detail.author}</Author>
         <Time>{detail.timestamp}</Time>
-        <Comment>{detail.comment}</Comment>
+        <FormGroup>
+          <StyledTxtarea value={comment} onChange={onChangeComment} />
+        </FormGroup>
         <BtnWrapper>
-          <Button txt="수정" fontSize="1.875rem" />
+          <Button txt="수정" onBtnClick={changeComment} fontSize="1.875rem" />
           <Button txt="삭제" onBtnClick={deleteComment} fontSize="1.875rem" />
         </BtnWrapper>
       </DetailWrapper>
@@ -98,4 +123,29 @@ const BtnWrapper = styled.div`
   justify-content: center;
   align-items: center;
   gap: 1.25rem;
+`;
+
+const FormGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+`;
+
+const StyledTxtarea = styled.textarea`
+  border: none;
+  outline: none;
+  width: 100%;
+  height: 12.5rem;
+  background-color: white;
+  padding: 1.875rem;
+  border-radius: 0.9375rem;
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin: 3.125rem 0;
+  resize: none;
+  color: var(--text-black);
+  &::placeholder {
+    color: #acacac;
+    font-weight: 700;
+  }
 `;

--- a/frontend/FEweek07/week07/src/pages/DetailPage.jsx
+++ b/frontend/FEweek07/week07/src/pages/DetailPage.jsx
@@ -7,9 +7,9 @@ import axios from "axios";
 const DetailPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-  const [detail, setDetail] = useState([]);
   const baseURL = import.meta.env.VITE_API_BASE_URL;
 
+  const [detail, setDetail] = useState([]);
   const getDetail = (id) => {
     axios
       .get(`${baseURL}/entries/${id}/`)
@@ -19,6 +19,19 @@ const DetailPage = () => {
       })
       .catch((error) => {
         console.log(error);
+      });
+  };
+  const deleteComment = () => {
+    axios
+      .delete(`${baseURL}/entries/${id}/`)
+      .then((response) => {
+        console.log(response);
+        alert("게시글 삭제가 완료되었습니다.");
+        navigate("/");
+      })
+      .catch((error) => {
+        console.log(error);
+        alert("게시글을 삭제하지 못했습니다.");
       });
   };
 
@@ -34,7 +47,7 @@ const DetailPage = () => {
         <Comment>{detail.comment}</Comment>
         <BtnWrapper>
           <Button txt="수정" fontSize="1.875rem" />
-          <Button txt="삭제" fontSize="1.875rem" />
+          <Button txt="삭제" onBtnClick={deleteComment} fontSize="1.875rem" />
         </BtnWrapper>
       </DetailWrapper>
     </Wrapper>

--- a/frontend/FEweek07/week07/src/pages/WritePage.jsx
+++ b/frontend/FEweek07/week07/src/pages/WritePage.jsx
@@ -19,7 +19,7 @@ const WritePage = () => {
 
   const postComment = () => {
     axios
-      .post(`{${baseURL}/entries/}`, {
+      .post(`${baseURL}/entries/`, {
         author: author,
         comment: comment,
       })


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #34 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->

이번 과제는 7주차 세미나에서 배운 내용을 토대로 **API 명세서를 확인하여 게시글 수정, 삭제 연동하기** 이다.

**삭제 기능 연동**
힌트: 삭제 버튼에 onBtnClick={삭제함수} 추가하기

**삭제 함수 작성**

```
  const deleteComment = () => {
    axios
      .delete(`${baseURL}/entries/${id}/`)// API 명세서에 따라 게시글 삭제 기능은 REST 방식 중 DELETE를 사용하였다.
      .then((response) => {
        console.log(response);
        alert("게시글 삭제가 완료되었습니다.");
        navigate("/");
      })
      .catch((error) => {
        console.log(error);
        alert("게시글을 삭제하지 못했습니다.");
      });
  };
```

위의 코드는 백엔드 서버(${baseURL}/entries/${id}/)에 현재 id에 해당하는 게시글을 삭제하는 요청을 보내고,
삭제 성공 시 사용자에게 alert("게시글 삭제가 완료되었습니다."); 알림 후, 홈으로 보내준다.
삭제 실패 시 사용자에게 alert("게시글을 삭제하지 못했습니다."); 라는 메세지를 보여준다.


위와 같은 코드를 삭제 버튼을 눌렀을 때 실행되도록 만들기 위해 아래와 같은 코드를 작성하였다.

```
<ButtonContainer onClick={onBtnClick} fontSize={fontSize}>
   {txt || "버튼"}
</ButtonContainer>
```
현재 버튼 컴포넌트는 다음과 같이 작성되어 있는데, 이 구조에서 onBtnClick는 클릭 시 실행될 함수이다.

따라서 삭제 버튼을 누르면 삭제 기능이 수행되도록 설정해주려면
`<Button txt="삭제" onBtnClick={deleteComment} fontSize="1.875rem" />`
위와 같이 코드를 작성해주면 된다.

**초기 오류**
초기에 서버에 delete 요청을 보낼 때 url을 아래와 같이 사용하였다. `.delete(`${baseURL}/entries/`) `

이로 인해 아래와 같은 405 error가 발생했다.
<img width="819" height="202" alt="스크린샷 2025-07-14 오전 11 04 06" src="https://github.com/user-attachments/assets/08e6ffc5-ca47-4063-b2b2-8996be6e3db6" />

405 error란 해당 URL에서 요청한 HTTP 메서드(DELETE)를 허용하지 않는다, 즉 현재 url로는 delete 요청을 할 수 없다는 의미이다.

=> 따라서 정확하게 삭제할 수 있는 url로 수정이 필요하다!
API 명세서에 따라, 게시글 삭제 시 /entries/{int:entry_id}/ 형태로 url 수정이 필요하다
**entries/ → entries/${id}/**

이처럼 id를 포함한 url로 요청을 보내야 서버가 어떤 게시글을 삭제해야하는지 정확히 알 수 있다.

잘못된 코드: **.delete(`${baseURL}/entries/`)** -> 405 에러
올바른 코드: **.delete(`${baseURL}/entries/${id}/`)** -> 성공

**수정 기능 연동**
힌트: 수정 전의 내용들을 받아와서 **input**의 초기값으로 보여주면 좋을 것 같다
-> input!이 힌트

**수정 함수 작성**

```
const changeComment = () => {
    axios
      .put(`${baseURL}/entries/${id}/`, {
        author: author,
        comment: comment,
      })
      .then((response) => {
        console.log(response);
        alert("게시글 수정이 완료되었습니다.");
        navigate("/");
      })
      .catch((error) => {
        console.log(error);
        alert("게시글을 수정하지 못했습니다.");
      });
  };
```
위의 함수는 게시글 수정을 위한 요청을 서버에 보내고,
수정 성공 시 사용자에게 alert("게시글 수정이 완료되었습니다."); 알림 후, 홈으로 보내준다.
수정 실패 시 사용자에게 alert("게시글을 수정하지 못했습니다."); 라는 메세지를 보여준다.

이전에 삭제 기능에서 발생했던 405 오류 경험을 바탕으로, 이번에는 API 명세서를 정확히 확인하고
메서드는 PUT을 사용하고, URL은 /entries/{int:entry_id}/ 형식으로 작성하였다.

또한 수정 버튼 클릭 시 수정 함수가 실행되도록 하기 위해 
`<Button txt="수정" onBtnClick={changeComment} fontSize="1.875rem" />`
버튼 컴포넌트의 onBtnClick 속성에 changeComment 함수를 연결해주었다.

그러나 위와 같이 작성했을 때 아래와 같은 오류가 발생했다.
<img width="1421" height="200" alt="스크린샷 2025-07-14 오후 12 43 33" src="https://github.com/user-attachments/assets/871a05eb-efd2-45bc-a896-a409f0cfdc5c" />

위는 400 에러로, PUT 요청에서 보낸 데이터가 잘못되었을 때 발생한다.
보통 보내고자 하는 값이 하나라도 빈 값이거나 누락 되었을 때/ key이름이 API 명세서와 다를 때/ 형식 자체가 잘못되었을 때 발생한다.

발생한 원인은 바로 아래의 코드였다.

```
const [author, setAuthor] = useState("");
const [comment, setComment] = useState("");

const onChangeAuthor = (e) => {
  setAuthor(e.target.value);
};
const onChangeComment = (e) => {
  setComment(e.target.value);
};

.put(`${baseURL}/entries/${id}/`, {
  author: author,
  comment: comment,
})
```

원인은 바로 상태(author, comment)의 초기값을 빈 문자열로 설정해주었는데, 이후 setAuthor(), setCommet()를 호출하여 값을 넣어주지 않아 서버에 아래와 같이 빈 값으로 요청이 전송되었다.

```
{
  "author": "",
  "comment": ""
}
```
서버는 author, commet의 값이 비어 있을 경우 유효하지 않은 요청(Invalid request body)으로 판단하고 오류를 반환한다. 따라서 서버에 보낼 때 각 상태에 값이 잘 채워져 보내질 수 있도록 코드를 수정해야 한다.

먼저 author는 수정 대상이 아니기 때문에 author를 상태로 관리할 필요가 없다. 따라서 관련 코드를 삭제하고 수정 요청 시 기존의 값을 그대로 사용하도록 코드를 변경해주어야 한다.

삭제한 코드
```
const [author, setAuthor] = useState("");

const onChangeAuthor = (e) => {
  setAuthor(e.target.value);
};
```

수정한 코드
```
.put(`${baseURL}/entries/${id}/`, {
        author: detail.author, // author: author -> author: detail.author로 수정
        comment: comment,
      })
```

또한 사용자가 수정할 내용을 입력할 수 있도록 textarea 필드를 return 문에 추가해주어야 한다.

수정된 return문
```
return (
    <Wrapper>
      <Button txt="게시글 작성하기" onBtnClick={() => navigate("/write")} />
      <DetailWrapper>
        <Author>{detail.author}</Author>
        <Time>{detail.timestamp}</Time>
        <FormGroup>
          <StyledTxtarea value={comment} onChange={onChangeComment} />
        </FormGroup>
        <BtnWrapper>
          <Button txt="수정" onBtnClick={changeComment} fontSize="1.875rem" />
          <Button txt="삭제" onBtnClick={deleteComment} fontSize="1.875rem" />
        </BtnWrapper>
      </DetailWrapper>
    </Wrapper>
  );
```

그러나 위와 같이 코드를 작성하였더니, 게시글에 들어갔을 때 기존 게시글 내용이 보이지 않고 textarea 입력창만 존재하는 문제가 발생하였다.

이를 해결하기 위해 처음에는 placeholder 이용해 보았다.

**1. placeholder 이용**
textarea 필드의 속성에 placeholder={`${detail.comment}`}를 추가해 주었더니
<img width="1272" height="684" alt="스크린샷 2025-07-14 오후 1 05 07" src="https://github.com/user-attachments/assets/3e9e81c1-353b-4c24-801a-b8c7bd3360d5" />
위와 같이 입력창 안에 기존 게시글 내용이 흐리게 표시되었다.
그러나 placeholder는 실제 내용이 있는 것이 아닌 입력 예시를 보여주는 것이기 때문에 실제로 입력창 안에 아무 값도 들어가 있지 않다. 그 결과 사용자가 수정 없이 바로 수정을 눌렀을 때(기존 내용을 그대로 유지하기 위해) 다시 400 에러를 발생시킨다는 오류가 있었다.

위와 같은 현상을 해결하기 위해 textarea의 value 속성을 detail.comment로 직접 지정해주었다
**2. `<StyledTxtarea value={detail.comment} onChange={onChangeComment} />`**

<img width="1274" height="668" alt="스크린샷 2025-07-14 오후 1 08 22" src="https://github.com/user-attachments/assets/7adf7b6c-666e-42f8-8318-7ddd2275047c" />
이 방법을 사용하면 기존 게시글 내용이 입력창에 정상적으로 표시되는 것을 확인할 수 있었다.

그러나 위의 방법은 해당 필드에 입력을 시도해도 값이 수정되지 않는다는 문제가 존재했다.
이는 value를 detail.comment로 고정시켰기 때문에 내용을 수정하려 시도해도 입력값이 변경되지 않고 계속 기존 값으로 남아있게 된 것이었다.

따라서 위의 문제를 해결하기 위해 useEffect를 활용하였다.
```
  useEffect(() => {
    if (detail) {
      setComment(detail.comment || "");
    }
  }, [detail]);
```
위와 같은 코드를 추가해주어 detail이 존재한다면, 즉 이전에 작성한 내용이 존재한다면 해당 detail.comment 값을 comment의 상태에 저장하고 존재하지 않을 경우 빈 문자열로 초기화한다.

이를 통해 textarea의 value를 comment 상태와 연결하여 입력창에는 기존 게시글 내용이 들어가고, 사용자는 그 내용을 자유롭게 수정할 수 있게 된다.

추가적으로 textarea의 value 속성도 함께 수정해주어야 한다!!
수정 전: <StyledTxtarea value={detail.comment} onChange={onChangeComment} />
수정 후:<StyledTxtarea value={comment} onChange={onChangeComment} />

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
https://github.com/user-attachments/assets/13cb2653-5c28-4819-84f6-c2c18cbc8f53

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 



